### PR TITLE
Recreate reply.locals on every request so we don't bleed globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,12 @@ function plugin(fastify, opts, next) {
     }
   }
 
-  fastify.decorateReply('locals', {});
+  function locals(req, reply, done) {
+    reply.locals = {};
+    done();
+  }
+
+  fastify.addHook('preHandler', locals);
   fastify.decorateReply(decorator, function() {
     renderer.apply(this, arguments);
   });


### PR DESCRIPTION
@scottkipfer 