### PR TITLE
READY: Support loading templates from elsewhere

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ function plugin(fastify, opts, next) {
     process.exit(1);
   }
 
-  const getPage = page => `${templateDirectory}/${page}.html`;
+  const getPage = page => `${templateDirectory}/${page}`;
+  const isAbsolute = path => path.startsWith('/');
+
+  // Ends with .ext (but doesn't start with . (e.g. a hidden file)
+  const hasExt = path => /^[^.]+\.[a-zA-Z0-9-]+$/.test(path);
 
   function renderer(path, data) {
     const json = this.request.query.json;
@@ -44,7 +48,9 @@ function plugin(fastify, opts, next) {
       this.send({data: data, locals: this.locals});
     } else {
       try {
-        const page = getPage(path);
+        let page = isAbsolute(path) ? path : getPage(path);
+        if (!hasExt(page)) page = `${ page }.html`;
+
         const view = sqrly.renderFile(page, {...this.locals, ...data});
         this.header("Content-Type", `text/html; charset=${charset}`);
         this.send(view);

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ function plugin(fastify, opts, next) {
   const autoEscape = opts.autoEscape || false;
   const decorator = opts.decorator || "sqrly";
   const charset = opts.charset || "utf-8";
-  const templateDirectory = opts.templates || path.join(cwd, "/templates");
-  const partialsDirectory = opts.partials || path.join(cwd, "/partials");
-  const helpersDirectory = opts.helpers || path.join(cwd, "/helpers");
-  const filtersDirectory = opts.filters || path.join(cwd, "/filters");
-  const nativeDirectory = opts.nativeHelpers || path.join(cwd, "/nativeHelpers");
+  const templateDirectory = opts.templates || path.join(cwd, "templates");
+  const partialsDirectory = opts.partials || path.join(cwd, "partials");
+  const helpersDirectory = opts.helpers || path.join(cwd, "helpers");
+  const filtersDirectory = opts.filters || path.join(cwd, "filters");
+  const nativeDirectory = opts.nativeHelpers || path.join(cwd, "nativeHelpers");
 
   function _import(dir, sqrlyMethod, importMethod) {
     const paths = fs.existsSync(dir) ? klaw(dir, { nodir: true }) : [];
@@ -37,18 +37,17 @@ function plugin(fastify, opts, next) {
   }
 
   const getPage = page => `${templateDirectory}/${page}`;
-  const isAbsolute = path => path.startsWith('/');
 
   // Ends with .ext (but doesn't start with . (e.g. a hidden file)
   const hasExt = path => /^[^.]+\.[a-zA-Z0-9-]+$/.test(path);
 
-  function renderer(path, data) {
+  function renderer(template, data) {
     const json = this.request.query.json;
     if (json && debug) {
       this.send({data: data, locals: this.locals});
     } else {
       try {
-        let page = isAbsolute(path) ? path : getPage(path);
+        let page = path.isAbsolute(template) ? template : getPage(template);
         if (!hasExt(page)) page = `${ page }.html`;
 
         const view = sqrly.renderFile(page, {...this.locals, ...data});


### PR DESCRIPTION
@scottkipfer This lets you load templates from a directory _other than_ the one you specify on server start (as long as it's absolute), which would let you bundle common views into other repos. So you could do, for example:

```
reply.view(path.resolve(__dirname, 'node_modules/common-templates/foo.html'), { data })
```