### PR TITLE
Support multiple template (etc) directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,28 +4,54 @@ const path = require("path");
 const klaw = require("klaw-sync");
 const fs = require("fs");
 
+function arrayify(maybeArr) {
+  return typeof maybeArr === 'string' ? [maybeArr] : maybeArr;
+}
+
+function getPaths(dir) {
+  return fs.existsSync(dir) ? klaw(dir, { nodir: true }) : [];
+}
+
 function plugin(fastify, opts, next) {
   const cwd = path.dirname(process.mainModule.filename);
   const debug = opts.debug || false;
   const autoEscape = opts.autoEscape || false;
   const decorator = opts.decorator || "sqrly";
   const charset = opts.charset || "utf-8";
-  const templateDirectory = opts.templates || path.join(cwd, "templates");
-  const partialsDirectory = opts.partials || path.join(cwd, "partials");
-  const helpersDirectory = opts.helpers || path.join(cwd, "helpers");
-  const filtersDirectory = opts.filters || path.join(cwd, "filters");
-  const nativeDirectory = opts.nativeHelpers || path.join(cwd, "nativeHelpers");
+  const templateDirectory = arrayify(opts.templates || path.join(cwd, "templates"));
+  const partialsDirectory = arrayify(opts.partials || path.join(cwd, "partials"));
+  const helpersDirectory = arrayify(opts.helpers || path.join(cwd, "helpers"));
+  const filtersDirectory = arrayify(opts.filters || path.join(cwd, "filters"));
+  const nativeDirectory = arrayify(opts.nativeHelpers || path.join(cwd, "nativeHelpers"));
 
-  function _import(dir, sqrlyMethod, importMethod) {
-    const paths = fs.existsSync(dir) ? klaw(dir, { nodir: true }) : [];
-    paths.forEach(({ path }) => {
-      const file = importMethod(path);
-      const importName = path.split(dir).join("").replace(/\.[^/.]+$/, "").replace(/^\//g, "");
-      sqrlyMethod(importName, file);
-    });
+  let templates = {};
+
+  function _import(_dir, sqrlyMethod, importMethod) {
+    for (let dir of _dir) {
+      const paths = getPaths(dir);
+      paths.forEach(({ path }) => {
+        const file = importMethod(path);
+        const importName = path.split(dir).join("").replace(/\.[^/.]+$/, "").replace(/^\//g, "");
+        sqrlyMethod(importName, file);
+      });
+    }
   }
 
   try {
+    templates = templateDirectory.reduce((acc, dir) => {
+      const fds = getPaths(dir);
+      for (let { path: p } of fds) {
+        let key = p.replace(`${ dir }/`, '');
+        let ext = key.lastIndexOf('.');
+        // If . is first, do nothing
+        if (ext > 0) {
+          key = key.slice(0, ext);
+        }
+        acc[key] = dir;
+      }
+      return acc;
+    }, templates);
+
     sqrly.autoEscaping(autoEscape);
     _import(partialsDirectory, sqrly.definePartial, fs.readFileSync);
     _import(helpersDirectory, sqrly.defineHelper, require);
@@ -36,7 +62,7 @@ function plugin(fastify, opts, next) {
     process.exit(1);
   }
 
-  const getPage = page => `${templateDirectory}/${page}`;
+  const getPage = page => `${templates[page]}/${page}`;
 
   // Ends with .ext (but doesn't start with . (e.g. a hidden file)
   const hasExt = path => /^[^.]+\.[a-zA-Z0-9-]+$/.test(path);
@@ -61,7 +87,7 @@ function plugin(fastify, opts, next) {
   }
 
   function locals(req, reply, done) {
-    reply.locals = {};
+    reply.locals = reply.locals || {};
     done();
   }
 


### PR DESCRIPTION
Tested this against manta-frontend via `npm link` and it is working. I figured trying to fix our directory structure would be a useful thing prior to leaving.